### PR TITLE
hooked hotkey actions into model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# personal config
+config.json
+
 # anything that could possibly show up
 .python-version
 .env
@@ -28,3 +31,4 @@ MANIFEST
 .DS_Store
 .idea/
 .vscode
+__pycache__

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # nuzlocke-tracker
 
-cross-platform text-recognition-based nuzlocke tracker tool (WIP for gen iv)
+cross-platform text-recognition-based nuzlocke tracker tool (WIP for platinum)
+
+user note: either `config.defaults.json` or `config.json` may be edited to change the configuration of the tracker - `config.json` takes priority, so you can edit that to keep the default settings backed up in `config.defaults.json`, or you can just edit `config.defaults.json` directly if you don't care
+
+dev note: duplicate `config.defaults.json` as `config.json` to change stuff locally without affecting the defaults for users
+
 
 we're using pipenv to run this project (`pipenv install` to install dependencies, and `pipenv run python` where you would normally use `python` to run scripts), but this may work just fine if you have the appropriate packages availabe in another manner
 

--- a/config.defaults.json
+++ b/config.defaults.json
@@ -4,6 +4,8 @@
         "Send to box": "b",
         "Mark dead": "d",
         "Fail the encounter": "f",
-        "Edit an encounter": "<shift>+e"
+        "Edit an encounter": "<shift>+e",
+        "Undo action": "<shift>+z",
+        "Redo action": "<shift>+y"
     }
 }

--- a/config.defaults.json
+++ b/config.defaults.json
@@ -1,8 +1,8 @@
 {
     "keybinds": {
-        "Mark dead": "d",
         "Send to party": "p",
         "Send to box": "b",
+        "Mark dead": "d",
         "Fail the encounter": "f",
         "Edit an encounter": "<shift>+e"
     }

--- a/config.json
+++ b/config.json
@@ -1,0 +1,9 @@
+{
+    "keybinds": {
+        "Mark dead": "d",
+        "Send to party": "p",
+        "Send to box": "b",
+        "Fail the encounter": "f",
+        "Edit an encounter": "<shift>+e"
+    }
+}

--- a/src/keyboard_input.py
+++ b/src/keyboard_input.py
@@ -1,35 +1,53 @@
 from pynput import keyboard
+from common import bold, reset, dbg
+from collections import deque
 import json
 
 
-def on_PartyToDead():
-    print("Mark dead")
+event_queue = deque()
+"""pop from left to dequeue in order (events are appended from right)"""
 
 
 def on_ToParty():
-    print("Send to party")
+    dbg("HOTKEY", "Send to party")
+    event_queue.append("ToParty")
 
 
 def on_ToBoxed():
-    print("Send to box")
+    dbg("HOTKEY", "Send to box")
+    event_queue.append("ToBoxed")
+
+
+def on_PartyToDead():
+    dbg("HOTKEY", "Mark dead")
+    event_queue.append("ToDead")
 
 
 def on_FailEnc():
-    print("Fail the encounter")
+    dbg("HOTKEY", "Fail the encounter")
+    event_queue.append("FailEnc")
 
 
 def on_EditEnc():
-    print("Edit an encounter")
+    dbg("HOTKEY", "Edit an encounter")
+    event_queue.append("EditEnc")
 
 
-config = json.load(open("config.json")).get("keybinds")
+try:
+    config = json.load(open("config.json")).get("keybinds")
+except:
+    config = json.load(open("config.defaults.json")).get("keybinds")
+finally:
+    print(f"{bold}Configured hotkeys{reset}")
+    for action, keybind in config.items():
+        print(f"  {action}: {bold}{keybind}{reset}")
+
 hotkeys = dict()
-hotkeys[config.get("Mark dead")] = on_PartyToDead
 hotkeys[config.get("Send to party")] = on_ToParty
 hotkeys[config.get("Send to box")] = on_ToBoxed
+hotkeys[config.get("Mark dead")] = on_PartyToDead
 hotkeys[config.get("Fail the encounter")] = on_FailEnc
 hotkeys[config.get("Edit an encounter")] = on_EditEnc
-
 
 globalHotkeys = keyboard.GlobalHotKeys(hotkeys)
 globalHotkeys.start()

--- a/src/keyboard_input.py
+++ b/src/keyboard_input.py
@@ -33,6 +33,16 @@ def on_EditEnc():
     event_queue.append("EditEnc")
 
 
+def on_Undo():
+    dbg("HOTKEY", "Undo action")
+    event_queue.append("UndoAction")
+
+
+def on_Redo():
+    dbg("HOTKEY", "Redo action")
+    event_queue.append("RedoAction")
+
+
 try:
     config = json.load(open("config.json")).get("keybinds")
 except:
@@ -48,6 +58,8 @@ hotkeys[config.get("Send to box")] = on_ToBoxed
 hotkeys[config.get("Mark dead")] = on_PartyToDead
 hotkeys[config.get("Fail the encounter")] = on_FailEnc
 hotkeys[config.get("Edit an encounter")] = on_EditEnc
+hotkeys[config.get("Undo action")] = on_Undo
+hotkeys[config.get("Redo action")] = on_Redo
 
 globalHotkeys = keyboard.GlobalHotKeys(hotkeys)
 globalHotkeys.start()

--- a/src/keyboard_input.py
+++ b/src/keyboard_input.py
@@ -1,0 +1,35 @@
+from pynput import keyboard
+import json
+
+
+def on_PartyToDead():
+    print("Mark dead")
+
+
+def on_ToParty():
+    print("Send to party")
+
+
+def on_ToBoxed():
+    print("Send to box")
+
+
+def on_FailEnc():
+    print("Fail the encounter")
+
+
+def on_EditEnc():
+    print("Edit an encounter")
+
+
+config = json.load(open("config.json")).get("keybinds")
+hotkeys = dict()
+hotkeys[config.get("Mark dead")] = on_PartyToDead
+hotkeys[config.get("Send to party")] = on_ToParty
+hotkeys[config.get("Send to box")] = on_ToBoxed
+hotkeys[config.get("Fail the encounter")] = on_FailEnc
+hotkeys[config.get("Edit an encounter")] = on_EditEnc
+
+
+globalHotkeys = keyboard.GlobalHotKeys(hotkeys)
+globalHotkeys.start()

--- a/src/main.py
+++ b/src/main.py
@@ -4,6 +4,7 @@ import cv2 as opencv
 from mss import mss
 import en_model as model
 from common import reset, bold, italic, dbg
+from keyboard_input import globalHotkeys
 
 
 def print_arg_help():

--- a/src/main.py
+++ b/src/main.py
@@ -4,7 +4,7 @@ import cv2 as opencv
 from mss import mss
 import en_model as model
 from common import reset, bold, italic, dbg
-from keyboard_input import globalHotkeys
+from keyboard_input import globalHotkeys, event_queue
 
 
 def print_arg_help():
@@ -62,6 +62,7 @@ if __name__ == "__main__":
             )
 
             model.process_frame(state, res)  # may mutate state
+            # TODO use event_queue
 
             if state.__repr__() != last_loc:
                 last_loc = state.__repr__()

--- a/src/main.py
+++ b/src/main.py
@@ -62,7 +62,8 @@ if __name__ == "__main__":
             )
 
             model.process_frame(state, res)  # may mutate state
-            # TODO use event_queue
+            if event_queue:  # implicitly evaluates false if empty
+                model.handle_event(state, event_queue.popleft())
 
             if state.__repr__() != last_loc:
                 last_loc = state.__repr__()


### PR DESCRIPTION
now hotkey actions update the state when applicable (note: this doesn't guard against all edge cases yet, so a user can get the tracker to register actions that are mutually incompatible—like adding an encounter to both party and box)

**this shouldn't be merged in until the most obvious edge cases are taken care of**
(the debug log shows all hotkey events, but it also prints the following action when applicable)